### PR TITLE
Fix/change script to pass shellcheck and docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: themattrix/tox
+      image: alpine:latest 
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Package installation
-        run: apt-get update -y && apt-get install -y shellcheck
+        run: apk add --no-cache shellcheck python3 py3-pip && pip3 install tox
       - name: Shellcheck call tests
         run: shellcheck --shell=bash *.sh
       - name: Tox call tests

--- a/get_gerrit_last_comment_by_data.sh
+++ b/get_gerrit_last_comment_by_data.sh
@@ -79,12 +79,12 @@ fi
 ssh_command=("ssh" "-p" "$port" "$ssh_user@$gerrit_host")
 gerrit_command=( "gerrit" "query" "--comments" "change:$change_number" "--format=json" "commentby:$gerrit_username")
 
-if [ ! -z "$ssh_key_path" ]; then
+if [ -n "$ssh_key_path" ]; then
     if [ ! -f "$ssh_key_path" ]; then
         echo "SSH key '$ssh_key_path' not found"
         exit 2
     fi
-    ssh_command+=('-i' $ssh_key_path)
+    ssh_command+=('-i' "$ssh_key_path")
 fi
 
 review_data=$("${ssh_command[@]}" "${gerrit_command[@]}")
@@ -114,7 +114,7 @@ last_comment=$(jq -r 'last | .[]' <<< "$last_comment_review_info" \
                       | awk '/^-/{print $2,$3,$5}')
 
 jq_extract_jobs_data_command=("jq" "-c" ".[]")
-if [ ! -z "$get_failure_jobs" ]; then
+if [ -n "$get_failure_jobs" ]; then
     jq_extract_jobs_data_command=("jq" "-r" "'[.data | .[] | select(.status==\"FAILURE\")]'")
 fi
 


### PR DESCRIPTION
There's a big difference changing the docker images from Ubuntu to Alpine for this CI. 

-There is a size difference between them (the alpine example size is with a built image I've created with all the packages we need):

```
$ echo $(($(docker image inspect themattrix/tox:latest --format='{{.Size}}' ) / 1000000))
1573
$ echo $(($(docker image inspect alpine_testing --format='{{.Size}}' ) / 1000000))
101
```

- There's a build time difference:

```
Ubuntu -> 53s
Alpine -> 21s
```

- The packages are recent:

```
root@8b2112dc55d1:/app# cat /etc/issue
Ubuntu 16.04.5 LTS \n \l
root@8b2112dc55d1:/app# shellcheck --version
ShellCheck - shell script analysis tool
version: 0.3.7
```

VS Alpine:

```
/ # shellcheck --version
ShellCheck - shell script analysis tool
version: 0.7.2
```

______________

- Fix script to pass shellcheck. It has been texted.
